### PR TITLE
Ability to set tags from defined columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Options:
   --password TEXT                 Pasword for authentication
   --database TEXT                 Database name
   --measurement TEXT              Measurement name
+  --tags-columns TEXT             Columns that should be tags eg.
+                                  test,test2,test3
   --timestamp-column TEXT         Name of the column to use as timestamp;
                                   if option is not set,
                                   the current timestamp is used

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -275,7 +275,7 @@ class CsvImporter(object):
                                     tags[column] = row_copy[column]
                                     del row_copy[column]
                 else:
-                    tags=None
+                    tags = None
                 self.write_measurement(
                     self.cfg_measurement,
                     row_copy,

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -40,6 +40,7 @@ class CsvImporter(object):
         self.cfg_password = None
         self.cfg_database = None
         self.cfg_measurement = None
+        self.cfg_tags_columns = None
         self.cfg_timestamp_column = None
         self.cfg_timestamp_format = None
         self.cfg_timestamp_timezone = None
@@ -89,6 +90,13 @@ class CsvImporter(object):
             .replace(')', '')
         logging.debug('InfluxDB measurement is set to "' +
                       self.cfg_measurement + '"')
+
+    def set_tags_columns(self, tags_columns):
+        """Sets columns in csv that should be tags"""
+        tags_columns_orig = tags_columns
+        self.cfg_tags_columns = tags_columns.split(',')
+        logging.debug('Tags are set to "' +
+                tags_columns_orig + '"')
 
     def set_timestamp_column(self, column):
         """Sets the column to use as timestamp"""
@@ -255,9 +263,23 @@ class CsvImporter(object):
                     row_copy = CsvImporter.convert_int_to_float(row_copy)
 
             if row_copy is not None:
+                if self.cfg_tags_columns is not None:
+                   tags = {}
+                   for column in self.cfg_tags_columns:
+                     if row_copy is not None:
+                        if column in row_copy:
+                           if column == '' or row_copy[column] == '':
+                              del row_copy[column]
+                              continue
+                           else:
+                              tags[column] = row_copy[column]
+                              del row_copy[column]
+                else:
+                   tags=None
                 self.write_measurement(
                     self.cfg_measurement,
                     row_copy,
+                    tags=tags,
                     time=utc_timestamp)
 
 
@@ -281,6 +303,8 @@ class CsvImporter(object):
               help='Database name')
 @click.option('--measurement',
               help='Measurement name')
+@click.option('--tags-columns',
+              help='Columns that should be tags eg. test,test2,test3')
 @click.option('--timestamp-column',
               help='Name of the column to use as timestamp; \
               if option is not set, the current timestamp is used')
@@ -348,6 +372,8 @@ def cli(*args, **kwargs):
         csv_importer.set_database(kwargs['database'])
     if kwargs['measurement']:
         csv_importer.set_measurement(kwargs['measurement'])
+    if kwargs['tags_columns']:
+        csv_importer.set_tags_columns(kwargs['tags_columns'])
     if kwargs['timestamp_column']:
         csv_importer.set_timestamp_column(kwargs['timestamp_column'])
     if kwargs['timestamp_format']:

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -96,7 +96,7 @@ class CsvImporter(object):
         tags_columns_orig = tags_columns
         self.cfg_tags_columns = tags_columns.split(',')
         logging.debug('Tags are set to "' +
-                tags_columns_orig + '"')
+                      tags_columns_orig + '"')
 
     def set_timestamp_column(self, column):
         """Sets the column to use as timestamp"""
@@ -264,18 +264,18 @@ class CsvImporter(object):
 
             if row_copy is not None:
                 if self.cfg_tags_columns is not None:
-                   tags = {}
-                   for column in self.cfg_tags_columns:
-                     if row_copy is not None:
-                        if column in row_copy:
-                           if column == '' or row_copy[column] == '':
-                              del row_copy[column]
-                              continue
-                           else:
-                              tags[column] = row_copy[column]
-                              del row_copy[column]
+                    tags = {}
+                    for column in self.cfg_tags_columns:
+                        if row_copy is not None:
+                            if column in row_copy:
+                                if column == '' or row_copy[column] == '':
+                                    del row_copy[column]
+                                    continue
+                                else:
+                                    tags[column] = row_copy[column]
+                                    del row_copy[column]
                 else:
-                   tags=None
+                    tags=None
                 self.write_measurement(
                     self.cfg_measurement,
                     row_copy,

--- a/tests/test_csvimporter.py
+++ b/tests/test_csvimporter.py
@@ -123,6 +123,16 @@ class TestClass(object):
         self.actual.set_measurement(expected)
         assert self.actual.cfg_measurement == expected
 
+    @pytest.mark.parametrize('tags_columns,expected', [
+        ('test1', ['test1']),
+        ('test1,test2', ['test1', 'test2']),
+        ('test1,test2,test3', ['test1', 'test2', 'test3']),
+    ])
+
+    def test_set_tags_columns(self, tags_columns, expected):
+        self.actual.set_tags_columns(tags_columns)
+        assert self.actual.cfg_tags_columns == expected
+
     def test_set_timestamp_column(self):
         expected = 'date_col1'
         self.actual.set_timestamp_column(expected)

--- a/tests/test_csvimporter.py
+++ b/tests/test_csvimporter.py
@@ -128,7 +128,6 @@ class TestClass(object):
         ('test1,test2', ['test1', 'test2']),
         ('test1,test2,test3', ['test1', 'test2', 'test3']),
     ])
-
     def test_set_tags_columns(self, tags_columns, expected):
         self.actual.set_tags_columns(tags_columns)
         assert self.actual.cfg_tags_columns == expected


### PR DESCRIPTION
With this #PR we can define columns that will be converted to tags not fields.

```
  --tags-columns TEXT             Columns that should be tags eg.
                                  test,test2,test3
```
Example from DEBUG:
```
DEBUG: Tags are set to "branch,user,version"
```
And when we have csv column named branch or user or version than:
```
DEBUG: [{'fields': {'': '', 'time': '1515075128', 'build_duration': '7', 'warning_count': ''}, 'time': '2018-01-04T14:12:08Z', 'tags': {'user': 'michal.smaga@getbase.com'}, 'measurement': 'test_builds'}]
DEBUG: http://127.0.0.1:8086 "POST /write?db=jenkins HTTP/1.1" 204 0
```
Tags will be added only if key or value are not empty in csv column.

This feature should improve migration process and we can do an exact copy of DB with all fields in measurements and corresponding tags.