### PR TITLE
Support SSL, Non-numeric tags, Raw epoch timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,29 @@ $ ./csvimporter.py --help
 
 Usage: csvimporter.py [OPTIONS] CSVFILE
 
-    Commandline interface for InfluxDB / CSV Importer
+  Commandline interface for InfluxDB / CSV Importer
 
 Options:
     --delimiter TEXT                Delimiter of .csv file (Default: ,)
     --server TEXT                   Server address (Default: localhost)
     --port TEXT                     Server port (Default: 8086)
+    --ssl                           Use ssl for connection to InfluxDB
     --user TEXT                     User for authentication
     --password TEXT                 Pasword for authentication
     --database TEXT                 Database name
     --measurement TEXT              Measurement name
-    --tags-columns TEXT             Columns that should be tags
+    --tags-columns TEXT             Columns that should be tags         
                                     e.g. col1,col2,col3
     --timestamp-column TEXT         Name of the column to use as timestamp;
-                                    if option is not set,
-                                    the current timestamp is used
-    --timestamp-format [epoch|datetime]
-                                    Format of the timestamp column
-                                    used to parse all timestamp
-                                    (Default: epoch timestamp);
-                                    epoch = epoch / unix timestamp
+                                    if option is not set, the current timestamp
+                                    is used
+    --timestamp-format [epoch|datetime|raw]
+                                    Format of the timestamp column used
+                                    to parse all timestamp         
+                                    (Default: epoch timestamp);         
+                                    epoch = epoch / unix timestamp         
                                     datetime = normal date and/or time notation
+                                    raw = raw epoch timestamp, do not convert
     --timestamp-timezone TEXT       Timezone of the timestamp column
     --locale TEXT                   Locale for ctype, numeric and monetary
                                     values e.g. de_DE.UTF-8

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ ./csvimporter.py --help
 
 Usage: csvimporter.py [OPTIONS] CSVFILE
 
-  Commandline interface for InfluxDB / CSV Importer
+    Commandline interface for InfluxDB / CSV Importer
 
 Options:
     --delimiter TEXT                Delimiter of .csv file (Default: ,)
@@ -51,16 +51,16 @@ Options:
     --password TEXT                 Pasword for authentication
     --database TEXT                 Database name
     --measurement TEXT              Measurement name
-    --tags-columns TEXT             Columns that should be tags         
+    --tags-columns TEXT             Columns that should be tags
                                     e.g. col1,col2,col3
     --timestamp-column TEXT         Name of the column to use as timestamp;
                                     if option is not set, the current timestamp
                                     is used
     --timestamp-format [epoch|datetime|raw]
                                     Format of the timestamp column used
-                                    to parse all timestamp         
-                                    (Default: epoch timestamp);         
-                                    epoch = epoch / unix timestamp         
+                                    to parse all timestamp
+                                    (Default: epoch timestamp);
+                                    epoch = epoch / unix timestamp
                                     datetime = normal date and/or time notation
                                     raw = raw epoch timestamp, do not convert
     --timestamp-timezone TEXT       Timezone of the timestamp column

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -275,7 +275,7 @@ class CsvImporter(object):
                     tags=tags,
                     time=utc_timestamp)
                 measurements_count += 1
-        
+
         print(f"\nWrote {measurements_count} measurements to InfluxDB")
 
 


### PR DESCRIPTION
Hello there. I've had to make some changes to support my influxdb 1.8 migration for a couple databases that I had to rebuild. I found some issues:

- needed https
- suppress the float conversion for non-numeric tags
- i didn't need any timezone conversion, so just take it directly in from the csv
- print progress dot for non-debug level
- print total measurements added at the end