### PR TITLE
Support SSL, Non-numeric tags, Raw epoch timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,29 @@ $ ./csvimporter.py --help
 
 Usage: csvimporter.py [OPTIONS] CSVFILE
 
-    Commandline interface for InfluxDB / CSV Importer
+  Commandline interface for InfluxDB / CSV Importer
 
 Options:
     --delimiter TEXT                Delimiter of .csv file (Default: ,)
     --server TEXT                   Server address (Default: localhost)
     --port TEXT                     Server port (Default: 8086)
+    --ssl                           Use ssl for connection to InfluxDB
     --user TEXT                     User for authentication
     --password TEXT                 Pasword for authentication
     --database TEXT                 Database name
     --measurement TEXT              Measurement name
-    --tags-columns TEXT             Columns that should be tags
+    --tags-columns TEXT             Columns that should be tags         
                                     e.g. col1,col2,col3
     --timestamp-column TEXT         Name of the column to use as timestamp;
-                                    if option is not set,
-                                    the current timestamp is used
-    --timestamp-format [epoch|datetime]
-                                    Format of the timestamp column
-                                    used to parse all timestamp
-                                    (Default: epoch timestamp);
-                                    epoch = epoch / unix timestamp
+                                    if option is not set, the current timestamp
+                                    is used
+    --timestamp-format [epoch|datetime|raw]
+                                    Format of the timestamp column used
+                                    to parse all timestamp         
+                                    (Default: epoch timestamp);         
+                                    epoch = epoch / unix timestamp         
                                     datetime = normal date and/or time notation
+                                    raw = raw epoch timestamp, do not convert
     --timestamp-timezone TEXT       Timezone of the timestamp column
     --locale TEXT                   Locale for ctype, numeric and monetary
                                     values e.g. de_DE.UTF-8

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ ./csvimporter.py --help
 
 Usage: csvimporter.py [OPTIONS] CSVFILE
 
-  Commandline interface for InfluxDB / CSV Importer
+    Commandline interface for InfluxDB / CSV Importer
 
 Options:
     --delimiter TEXT                Delimiter of .csv file (Default: ,)
@@ -51,16 +51,16 @@ Options:
     --password TEXT                 Pasword for authentication
     --database TEXT                 Database name
     --measurement TEXT              Measurement name
-    --tags-columns TEXT             Columns that should be tags         
+    --tags-columns TEXT             Columns that should be tags
                                     e.g. col1,col2,col3
     --timestamp-column TEXT         Name of the column to use as timestamp;
                                     if option is not set, the current timestamp
                                     is used
     --timestamp-format [epoch|datetime|raw]
                                     Format of the timestamp column used
-                                    to parse all timestamp         
-                                    (Default: epoch timestamp);         
-                                    epoch = epoch / unix timestamp         
+                                    to parse all timestamp
+                                    (Default: epoch timestamp);
+                                    epoch = epoch / unix timestamp
                                     datetime = normal date and/or time notation
                                     raw = raw epoch timestamp, do not convert
     --timestamp-timezone TEXT       Timezone of the timestamp column

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -161,12 +161,12 @@ class CsvImporter(object):
             return False
 
     @staticmethod
-    def convert_int_to_float(data, tags_columns: list):
+    def convert_int_to_float(data, tags_columns=None):
         """Returns a dictionary where all integer values
         are converted to float"""
         if data is not None:
             for key, value in data.items():
-                if key not in tags_columns:
+                if not tags_columns or key not in tags_columns:
                     if value:
                         try:
                             data[key] = float(locale.atof(value))

--- a/csvimporter.py
+++ b/csvimporter.py
@@ -275,7 +275,7 @@ class CsvImporter(object):
                     tags=tags,
                     time=utc_timestamp)
                 measurements_count += 1
-        
+
         print(f"\nWrote {measurements_count} measurements to InfluxDB")
 
 

--- a/tests/test_csvimporter.py
+++ b/tests/test_csvimporter.py
@@ -51,6 +51,8 @@ def test_match_date_negativ(epoch_timestamp, date_str):
         datetime(2016, 9, 2, 8, 0, 11, tzinfo=timezone('UTC'))),
     ('1472803211', 'epoch', 'Europe/Berlin',
         datetime(2016, 9, 2, 8, 0, 11, tzinfo=timezone('UTC'))),
+    # Raw
+    ('1718109826000000000', 'raw', 'UTC', 1718109826000000000),
     # Unsupported format
     ('1472803211', 'foobar', 'UTC',
         datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone('UTC')))
@@ -59,20 +61,24 @@ def test_convert_into_utc_timestamp(date_str, fmt, tz, expected):
     assert CsvImporter.convert_into_utc_timestamp(date_str, fmt, tz) == expected
 
 
-@pytest.mark.parametrize('data,expected', [
-    ({'positiv_integer': '1'}, {'positiv_integer': 1.0}),
-    ({'negativ_integer': '-1'}, {'negativ_integer': -1.0}),
-    ({'positiv_float': '1.0'}, {'positiv_float': 1.0}),
-    ({'negativ_float': '-1.0'}, {'negativ_float': -1.0}),
-    ({'string': 'one'}, {'string': 'one'}),
-    ({'datetime': '2017-01-01 16:30'}, {'datetime': '2017-01-01 16:30'}),
-    ({'date': '2017-01-01'}, {'date': '2017-01-01'}),
-    ({'date_german': '01.01.2017'}, {'date_german': '01.01.2017'}),
-    ({'time': '16:30'}, {'time': '16:30'}),
-    (None, None)
+@pytest.mark.parametrize('data,expected,tags_columns', [
+    # Without tags_columns
+    ({'positiv_integer': '1'}, {'positiv_integer': 1.0}, None),
+    ({'negativ_integer': '-1'}, {'negativ_integer': -1.0}, None),
+    ({'positiv_float': '1.0'}, {'positiv_float': 1.0}, None),
+    ({'negativ_float': '-1.0'}, {'negativ_float': -1.0}, None),
+    ({'string': 'one'}, {'string': 'one'}, None),
+    ({'datetime': '2017-01-01 16:30'}, {'datetime': '2017-01-01 16:30'}, None),
+    ({'date': '2017-01-01'}, {'date': '2017-01-01'}, None),
+    ({'date_german': '01.01.2017'}, {'date_german': '01.01.2017'}, None),
+    ({'time': '16:30'}, {'time': '16:30'}, None),
+    (None, None, None),
+    # With tags_columns
+    ({'positiv_integer': '1'}, {'positiv_integer': 1.0}, ['tag1']),
+    ({'tag1': 'xyz'}, {'tag1': 'xyz'}, ['tag1'])
 ])
-def test_convert_int_to_float(data, expected):
-    assert CsvImporter.convert_int_to_float(data) == expected
+def test_convert_int_to_float(data, expected, tags_columns):
+    assert CsvImporter.convert_int_to_float(data, tags_columns) == expected
 
 
 class TestClass(object):


### PR DESCRIPTION
Hello there. I've had to make some changes to support my influxdb 1.8 migration for a couple databases that I had to rebuild. I found some issues:

- needed https
- suppress the float conversion for non-numeric tags
- i didn't need any timezone conversion, so just take it directly in from the csv
- print progress dot for non-debug level
- print total measurements added at the end